### PR TITLE
Fixed BuildFireLine behavior

### DIFF
--- a/Assets/Scripts/BuildFireLine.cs
+++ b/Assets/Scripts/BuildFireLine.cs
@@ -35,7 +35,7 @@ public class BuildFireLine : MonoBehaviour
             energyLevel = gameObject.GetComponent<FireCrew>().energyLevel;
             
             // expend energy to dig the fire line
-            if (energyLevel >= WorkRate)
+            if (targetTile.GetComponent<TileScript>().fireLinePresent == false && energyLevel >= WorkRate)
             {
                 energyLevel -= WorkRate;
                 totalEnergyUsed += WorkRate;
@@ -43,10 +43,11 @@ public class BuildFireLine : MonoBehaviour
             else
             {
                 targetTile = null;
+                gameObject.GetComponent<FireCrew>().targetTile = null;
             }
 
             // required energy has been expended, so call BuildFireLine()
-            if (totalEnergyUsed >= FinishAmount)
+            if (totalEnergyUsed >= FinishAmount && targetTile.GetComponent<TileScript>().fireLinePresent == false)
             {
                 // Grab tile index
                 for(int i = 0; i < gameManager.AllTiles.Length; i++ ) 
@@ -54,8 +55,9 @@ public class BuildFireLine : MonoBehaviour
                     if(GameObject.ReferenceEquals(targetTile, gameManager.AllTiles[i])) tileIndex = i;
                 }
                 Debug.Log("Cleared vegetation on tile: " + (tileIndex + 1).ToString());
-                //targetTile.GetComponent<TileScript>().BuildFireLine();
+                targetTile.GetComponent<TileScript>().BuildFireLine();
                 targetTile = null;
+                gameObject.GetComponent<FireCrew>().targetTile = null;
             }
 
             // update the energy level of the calling unit

--- a/Assets/Scripts/ClearVegetation.cs
+++ b/Assets/Scripts/ClearVegetation.cs
@@ -43,6 +43,7 @@ public class ClearVegetation : MonoBehaviour
             else
             {
                 targetTile = null;
+                gameObject.GetComponent<FireCrew>().targetTile = null;
             }
 
             // required energy has been expended, so call DestroyObstacles()
@@ -56,6 +57,7 @@ public class ClearVegetation : MonoBehaviour
                 Debug.Log("Cleared vegetation on tile: " + (tileIndex + 1).ToString());
                 targetTile.GetComponent<TileScript>().DestroyObstacle();
                 targetTile = null;
+                gameObject.GetComponent<FireCrew>().targetTile = null;
             }
 
             // update the energy level of the calling unit

--- a/Assets/Scripts/FireCrew.cs
+++ b/Assets/Scripts/FireCrew.cs
@@ -60,6 +60,13 @@ public class FireCrew : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
+        // If we are near a firehouse, refill water and energy levels
+        if (currentTile.GetComponent<TileScript>().nearFireHouse == true)
+        {
+            waterLevel = 100;
+            energyLevel = 100;
+        }
+
         // If this is not the currently selected object, show the "unselected" sprite and remove the destination marker
         if (gameManager.SelectedUnit != gameObject)
         {
@@ -87,7 +94,7 @@ public class FireCrew : MonoBehaviour
                 gameManager.SelectedTile == currentTile.GetComponent<TileScript>().GetEast() ||
                 gameManager.SelectedTile == currentTile.GetComponent<TileScript>().GetSouth() ||
                 gameManager.SelectedTile == currentTile.GetComponent<TileScript>().GetWest()) &&
-                destinationTile == null && gameManager.SelectedTile.GetComponent<TileScript>().GetOccupied() == false)
+                destinationTile == null)
             {
                 if ((gameManager.SelectedTile.GetComponent<TileScript>().GetBurning() == true) && (gameManager.SprayWaterMode == true))
                 {
@@ -96,14 +103,16 @@ public class FireCrew : MonoBehaviour
                     TargetMarker.transform.position = targetTile.transform.position;
                     startDousing = true;
                 }
-                else if ((gameManager.SelectedTile.GetComponent<TileScript>().GetBurning() == false) && (gameManager.ClearVegMode == true))
+                else if ((gameManager.SelectedTile.GetComponent<TileScript>().GetBurning() == false) && (gameManager.ClearVegMode == true) &&
+                    (gameManager.SelectedTile.GetComponent<TileScript>().GetOccupied() == false))
                 {
                     targetTile = gameManager.SelectedTile;
                     TargetMarker.SetActive(true);
                     TargetMarker.transform.position = targetTile.transform.position;
                     startClearing = true;
                 }        
-                else if ((gameManager.SelectedTile.GetComponent<TileScript>().GetBurning() == false) && (gameManager.FireLineMode == true))
+                else if ((gameManager.SelectedTile.GetComponent<TileScript>().GetBurning() == false) && (gameManager.FireLineMode == true) && 
+                    (gameManager.SelectedTile.GetComponent<TileScript>().GetOccupied() == false)) 
                 {
                     targetTile = gameManager.SelectedTile;
                     TargetMarker.SetActive(true);
@@ -169,8 +178,8 @@ public class FireCrew : MonoBehaviour
             StopCoroutine(gameObject.GetComponent<SprayWater>().Douse(targetTile));
             StopCoroutine(gameObject.GetComponent<ClearVegetation>().Clear(targetTile));
             StopCoroutine(gameObject.GetComponent<BuildFireLine>().Build(targetTile));
-            TargetMarker.SetActive(false);
             targetTile = null;
+            TargetMarker.SetActive(false);
             startDousing = false;
             startClearing = false;
             startBuilding = false;

--- a/Assets/Scripts/FireTruck.cs
+++ b/Assets/Scripts/FireTruck.cs
@@ -50,6 +50,12 @@ public class FireTruck : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
+        // If we are near a firehouse, refill water tank
+        if (currentTile.GetComponent<TileScript>().nearFireHouse == true)
+        {
+            waterLevel = 100;
+        }
+
         // If this is not the currently selected object, show the "unselected" sprite and remove the destination marker
         if (gameManager.SelectedUnit != gameObject)
         {

--- a/Assets/Scripts/Helicopter.cs
+++ b/Assets/Scripts/Helicopter.cs
@@ -52,6 +52,12 @@ public class Helicopter : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
+        // If we are near a firehouse, refill water tank
+        if (currentTile.GetComponent<TileScript>().nearFireHouse == true)
+        {
+            waterLevel = 100;
+        }
+
         // If this is not the currently selected object, show the "unselected" sprite and remove the destination marker
         if (gameManager.SelectedUnit != gameObject)
         {

--- a/Assets/Scripts/SprayWater.cs
+++ b/Assets/Scripts/SprayWater.cs
@@ -55,6 +55,20 @@ public class SprayWater : MonoBehaviour
             else
             {
                 targetTile = null;
+
+                // update the target tile on the calling unit to indicate that we are done spraying water
+                if (gameObject.CompareTag("FireCrew"))
+                {
+                    gameObject.GetComponent<FireCrew>().targetTile = null;
+                }
+                else if (gameObject.CompareTag("FireTruck"))
+                {
+                    gameObject.GetComponent<FireTruck>().targetTile = null;
+                }
+                else if (gameObject.CompareTag("Helicopter"))
+                {
+                    gameObject.GetComponent<Helicopter>().targetTile = null;
+                }
             }
 
             // determine if the fire is extinguished yet
@@ -68,6 +82,20 @@ public class SprayWater : MonoBehaviour
                 Debug.Log("Put out fire on tile:" + (tileIndex + 1).ToString());
                 StartCoroutine(gameManager.GetComponent<GameManager>().PutOutFire(tileIndex));
                 targetTile = null;
+
+                // update the target tile on the calling unit to indicate that we are done spraying water
+                if (gameObject.CompareTag("FireCrew"))
+                {
+                    gameObject.GetComponent<FireCrew>().targetTile = null;
+                }
+                else if (gameObject.CompareTag("FireTruck"))
+                {
+                    gameObject.GetComponent<FireTruck>().targetTile = null;
+                }
+                else if (gameObject.CompareTag("Helicopter"))
+                {
+                    gameObject.GetComponent<Helicopter>().targetTile = null;
+                }
             }
 
             // update the water level of the calling unit

--- a/Assets/Tilemap/Water 2 Tiles/startScene.unitypackage.meta
+++ b/Assets/Tilemap/Water 2 Tiles/startScene.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 61a7c3de254c57b4094bca4277af2d67
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
The BuildFireLine behavior now works as intended.
SprayWater, ClearVegetation, and BuildFireLine will now all set their target tiles to "null" when finished, so the UI marker will disappear correctly.
Added ability for units to refill water & energy by going back to a fire house.