### PR TITLE
Reworked MoveToDest to prevent backtracking

### DIFF
--- a/Assets/Scripts/FireCrew.cs
+++ b/Assets/Scripts/FireCrew.cs
@@ -35,6 +35,7 @@ public class FireCrew : MonoBehaviour
     public GameObject targetTile;
     public GameObject TargetMarker;
 
+    private bool startMoving;
     private bool startDousing;
     private bool startClearing;
     private bool startBuilding;
@@ -49,6 +50,7 @@ public class FireCrew : MonoBehaviour
         DestinationMarker.SetActive(false);
         TargetMarker.SetActive(false);
         destinationTile = null;
+        startMoving = false;
         startDousing = false;
         startClearing = false;
         startBuilding = false;
@@ -80,9 +82,9 @@ public class FireCrew : MonoBehaviour
         {
             destinationTile = gameManager.SelectedTile;
             DestinationMarker.SetActive(true);
-            DestinationMarker.transform.position = destinationTile.transform.position;
             gameManager.SelectedTile = null;
             gameManager.DestSelectModeOn = false;
+            startMoving = true;
         }
 
         // If a target has been chosen for the crew to spray water on, update the variable
@@ -136,7 +138,11 @@ public class FireCrew : MonoBehaviour
         // move the crew to the next tile if not at the destination
         if ((destinationTile != null) && (currentTile != null) && (destinationTile != currentTile))
         {
-            StartCoroutine(gameObject.GetComponent<MoveToDest>().Move(currentTile, destinationTile, movementSpeed));
+            if (startMoving == true)
+            {
+                StartCoroutine(gameObject.GetComponent<MoveToDest>().Move(currentTile, destinationTile, movementSpeed));
+                startMoving = false;
+            }
 
             // This keeps the destination marker from moving along with the other objects in the FireCrew prefab
             DestinationMarker.transform.position = destinationTile.transform.position;

--- a/Assets/Scripts/FireTruck.cs
+++ b/Assets/Scripts/FireTruck.cs
@@ -30,6 +30,7 @@ public class FireTruck : MonoBehaviour
     public GameObject TargetMarker;
     public GameObject SelectionBox;
 
+    private bool startMoving;
     private bool startDousing;
 
     // Start is called before the first frame update
@@ -41,6 +42,7 @@ public class FireTruck : MonoBehaviour
         DestinationMarker.SetActive(false);
         TargetMarker.SetActive(false);
         destinationTile = null;
+        startMoving = false;
         startDousing = false;
 
         // mark the current tile as "occupied" so that other units & fires can't overlap
@@ -69,9 +71,9 @@ public class FireTruck : MonoBehaviour
         {
             destinationTile = gameManager.SelectedTile;
             DestinationMarker.SetActive(true);
-            DestinationMarker.transform.position = destinationTile.transform.position;
             gameManager.SelectedTile = null;
             gameManager.DestSelectModeOn = false;
+            startMoving = true;
         }
 
         // If a target has been chosen for the unit to spray water on, update the variable
@@ -102,7 +104,11 @@ public class FireTruck : MonoBehaviour
         // move the unit to the next tile if not at the destination
         if ((destinationTile != null) && (currentTile != null) && (destinationTile != currentTile))
         {
-            StartCoroutine(gameObject.GetComponent<MoveToDest>().Move(currentTile, destinationTile, movementSpeed));
+            if (startMoving == true)
+            {
+                StartCoroutine(gameObject.GetComponent<MoveToDest>().Move(currentTile, destinationTile, movementSpeed));
+                startMoving = false;
+            }
 
             // This keeps the destination marker from moving along with the other objects in the FireTruck prefab
             DestinationMarker.transform.position = destinationTile.transform.position;

--- a/Assets/Scripts/MoveToDest.cs
+++ b/Assets/Scripts/MoveToDest.cs
@@ -6,6 +6,13 @@ public class MoveToDest : MonoBehaviour
 {
     public GameObject nextTile;
     private float lastWaypointTime;
+    private List<GameObject> adjacentTiles = new List<GameObject>();
+    private List<GameObject> visitedTiles = new List<GameObject>();
+
+    private GameObject northTile;
+    private GameObject eastTile;
+    private GameObject southTile;
+    private GameObject westTile;
 
     // Start is called before the first frame update
     void Start()
@@ -22,184 +29,190 @@ public class MoveToDest : MonoBehaviour
     // Handle unit's movmenet to the destination
     public IEnumerator Move(GameObject currentTile, GameObject destinationTile, float movementSpeed)
     {
-        Vector3 currentTilePosition = currentTile.transform.position;
         Vector3 destPosition = destinationTile.transform.position;
         bool destUnreachable= false;
+        adjacentTiles.Clear();
+        visitedTiles.Clear();
 
-        // Choose the next tile to move to, if we haven't already
-        if (nextTile == null)
+        while(destUnreachable == false && currentTile != destinationTile)
         {
-            GameObject[] adjacentTiles = new GameObject[4];
-            int i = 0;
-            // populate "adjacentTiles[]", a list of all the unoccupied neighboring tiles
-            if ((currentTile.GetComponent<TileScript>().GetNorth() != null) && (currentTile.GetComponent<TileScript>().GetNorth() != currentTile))
-            {
-                adjacentTiles[i] = currentTile.GetComponent<TileScript>().GetNorth();
+            Vector3 currentTilePosition = currentTile.transform.position;
+            adjacentTiles.Clear();
 
-                // omit burning or occupied tiles
-                if (adjacentTiles[i].GetComponent<TileScript>().GetBurning() == true || adjacentTiles[i].GetComponent<TileScript>().GetOccupied() == true)
-                {
-                    if (adjacentTiles[i] == destinationTile)
-                    {
-                        // set this flag if we are next to the destination tile, but can't reach it
-                        destUnreachable = true;
-                    }
-                    else
-                    {
-                        adjacentTiles[i] = null;
-                    }
-                }
-                else 
-                {
-                    i++;
-                }
-            }
-            if ((currentTile.GetComponent<TileScript>().GetEast() != null) && (currentTile.GetComponent<TileScript>().GetEast() != currentTile))
-            {
-                adjacentTiles[i] = currentTile.GetComponent<TileScript>().GetEast();
-                
-                // omit burning or occupied tiles
-                if (adjacentTiles[i].GetComponent<TileScript>().GetBurning() == true || adjacentTiles[i].GetComponent<TileScript>().GetOccupied() == true)
-                {
-                    if (adjacentTiles[i] == destinationTile)
-                    {
-                        // set this flag if we are next to the destination tile, but can't reach it
-                        destUnreachable = true;
-                    }
-                    else
-                    {
-                        adjacentTiles[i] = null;
-                    }
-                }
-                else 
-                {
-                    i++;
-                }
-            }
-            if ((currentTile.GetComponent<TileScript>().GetSouth() != null) && (currentTile.GetComponent<TileScript>().GetSouth() != currentTile))
-            {
-                adjacentTiles[i] = currentTile.GetComponent<TileScript>().GetSouth();
-                
-                // omit burning or occupied tiles
-                if (adjacentTiles[i].GetComponent<TileScript>().GetBurning() == true || adjacentTiles[i].GetComponent<TileScript>().GetOccupied() == true)
-                {
-                    if (adjacentTiles[i] == destinationTile)
-                    {
-                        // set this flag if we are next to the destination tile, but can't reach it
-                        destUnreachable = true;
-                    }
-                    else
-                    {
-                        adjacentTiles[i] = null;
-                    }
-                }
-                else 
-                {
-                    i++;
-                }
-            }
-            if ((currentTile.GetComponent<TileScript>().GetWest() != null) && (currentTile.GetComponent<TileScript>().GetWest() != currentTile))
-            {
-                adjacentTiles[i] = currentTile.GetComponent<TileScript>().GetWest();
-                
-                // omit burning or occupied tiles
-                if (adjacentTiles[i].GetComponent<TileScript>().GetBurning() == true || adjacentTiles[i].GetComponent<TileScript>().GetOccupied() == true)
-                {
-                    if (adjacentTiles[i] == destinationTile)
-                    {
-                        // set this flag if we are next to the destination tile, but can't reach it
-                        destUnreachable = true;
-                    }
-                    else
-                    {
-                        adjacentTiles[i] = null;
-                    }
-                }
-                else 
-                {
-                    i++;
-                }
-            }
-
-            // find the adjacent tile that will bring us the closest to the destination tile
-            float minDistance = 9999.0f;
-            int minDistanceIndex = 0;
-            for (int j = 0; j<i; j++)
-            {
-                Vector3 nextPosition = adjacentTiles[j].transform.position;
-                float distance = Vector3.Distance(nextPosition, destPosition);
-
-                // find the minimum distance
-                if (distance < minDistance)
-                {
-                    minDistance = distance;
-                    minDistanceIndex = j;
-                }
-            }
-
-            // the next tile is the one with the shortest distance to the destination
-            if ((destUnreachable == false) && (adjacentTiles[minDistanceIndex] != null))
-            {
-                nextTile = adjacentTiles[minDistanceIndex];
-                lastWaypointTime = Time.time;
-            }
-            else
-            {
-                // can't reach destination tile, so stop here
-                nextTile = null;
-                destinationTile = currentTile;
-                Debug.Log("Destination cannot be reached!");
-
-                // set the calling unit's "destinationTile" parameter to the current tile
-                if (gameObject.CompareTag("FireCrew"))
-                {
-                    gameObject.GetComponent<FireCrew>().destinationTile = currentTile;
-                }
-                else if (gameObject.CompareTag("FireTruck"))
-                {
-                    gameObject.GetComponent<FireTruck>().destinationTile = currentTile;
-                }
-            }
-        }
-        else if (gameObject.transform.position.Equals(nextTile.transform.position))
-        {
-            // we have arrived at the next tile
-            currentTile.GetComponent<TileScript>().SetOccupied(false); // current tile is now unoccupied
-            nextTile.GetComponent<TileScript>().SetOccupied(true); // next tile is now occupied
-            currentTile = nextTile;
-            nextTile = null;
-
-            // update the calling unit's "currentTile" parameter
+            // keep the calling unit's destination marker from moving as the unit moves
             if (gameObject.CompareTag("FireCrew"))
             {
-                gameObject.GetComponent<FireCrew>().currentTile = currentTile;
+                gameObject.GetComponent<FireCrew>().DestinationMarker.transform.position = destinationTile.transform.position;
             }
             else if (gameObject.CompareTag("FireTruck"))
             {
-                gameObject.GetComponent<FireTruck>().currentTile = currentTile;
+                gameObject.GetComponent<FireTruck>().DestinationMarker.transform.position = destinationTile.transform.position;
             }
 
-        }
-        else
-        {
-            // keep moving to the next tile
-            Vector3 nextTilePosition = nextTile.transform.position;
-            float segmentLength = Vector3.Distance(currentTilePosition, nextTilePosition);
-            float totalSegmentTime = segmentLength / movementSpeed;
-            float timeOnSegment = Time.time - lastWaypointTime;
-            if (timeOnSegment < totalSegmentTime - 0.05)
+            // Choose the next tile to move to, if we haven't already
+            if (nextTile == null)
             {
-                // we are far away from the next tile, so keep moving
-                gameObject.transform.position = Vector2.Lerp(currentTilePosition, nextTilePosition, (timeOnSegment / totalSegmentTime));
+                northTile = currentTile.GetComponent<TileScript>().GetNorth();
+                eastTile = currentTile.GetComponent<TileScript>().GetEast();
+                southTile = currentTile.GetComponent<TileScript>().GetSouth();
+                westTile = currentTile.GetComponent<TileScript>().GetWest();
+
+                // populate "adjacentTiles", a list of all the unoccupied neighboring tiles
+                if ((northTile != null) && (northTile != currentTile))
+                {
+                    // omit burning or occupied tiles
+                    if (northTile.GetComponent<TileScript>().GetBurning() == true || northTile.GetComponent<TileScript>().GetOccupied() == true || visitedTiles.Contains(northTile))
+                    {
+                        if (northTile == destinationTile)
+                        {
+                            // set this flag if we are next to the destination tile, but can't reach it
+                            destUnreachable = true;
+                        }
+                    }
+                    else 
+                    {
+                        adjacentTiles.Add(northTile);
+                    }
+                }
+                if ((eastTile != null) && (eastTile != currentTile))
+                {
+                    // omit burning or occupied tiles
+                    if (eastTile.GetComponent<TileScript>().GetBurning() == true || eastTile.GetComponent<TileScript>().GetOccupied() == true || visitedTiles.Contains(eastTile))
+                    {
+                        if (eastTile == destinationTile)
+                        {
+                            // set this flag if we are next to the destination tile, but can't reach it
+                            destUnreachable = true;
+                        }
+                    }
+                    else 
+                    {
+                        adjacentTiles.Add(eastTile);
+                    }
+                }
+                if ((southTile != null) && (southTile != currentTile))
+                {               
+                    // omit burning or occupied tiles
+                    if (southTile.GetComponent<TileScript>().GetBurning() == true || southTile.GetComponent<TileScript>().GetOccupied() == true || visitedTiles.Contains(southTile))
+                    {
+                        if (southTile == destinationTile)
+                        {
+                            // set this flag if we are next to the destination tile, but can't reach it
+                            destUnreachable = true;
+                        }
+                    }
+                    else 
+                    {
+                        adjacentTiles.Add(southTile);
+                    }
+                }
+                if ((westTile != null) && (westTile != currentTile))
+                {
+                    // omit burning or occupied tiles
+                    if (westTile.GetComponent<TileScript>().GetBurning() == true || westTile.GetComponent<TileScript>().GetOccupied() == true || visitedTiles.Contains(westTile))
+                    {
+                        if (westTile == destinationTile)
+                        {
+                            // set this flag if we are next to the destination tile, but can't reach it
+                            destUnreachable = true;
+                        }
+                    }
+                    else 
+                    {
+                        adjacentTiles.Add(westTile);
+                    }
+                }
+
+                // find the adjacent tile that will bring us the closest to the destination tile
+                float minDistance = 9999.0f;
+                int minDistanceIndex = 0;
+                foreach (GameObject neighbor in adjacentTiles)
+                {
+                    Vector3 nextPosition = neighbor.transform.position;
+                    float distance = Vector3.Distance(nextPosition, destPosition);
+
+                    // find the minimum distance
+                    if (distance < minDistance)
+                    {
+                        minDistance = distance;
+                        minDistanceIndex = adjacentTiles.IndexOf(neighbor);
+                    }
+                }
+
+                // the next tile is the one with the shortest distance to the destination
+                if ((destUnreachable == false) && (adjacentTiles.Count > 0))
+                {
+                    nextTile = adjacentTiles[minDistanceIndex];
+                    lastWaypointTime = Time.time;
+                }
+                else
+                {
+                    // can't reach destination tile, so stop here
+                    nextTile = null;
+                    destinationTile = currentTile;
+                    Debug.Log("Destination cannot be reached!");
+
+                    // set the calling unit's "destinationTile" parameter to the current tile
+                    if (gameObject.CompareTag("FireCrew"))
+                    {
+                        gameObject.GetComponent<FireCrew>().destinationTile = currentTile;
+                    }
+                    else if (gameObject.CompareTag("FireTruck"))
+                    {
+                        gameObject.GetComponent<FireTruck>().destinationTile = currentTile;
+                    }
+                }
+            }
+            else if (gameObject.transform.position.Equals(nextTile.transform.position))
+            {
+                // we have arrived at the next tile
+                currentTile.GetComponent<TileScript>().SetOccupied(false); // current tile is now unoccupied
+                nextTile.GetComponent<TileScript>().SetOccupied(true); // next tile is now occupied
+                visitedTiles.Add(currentTile);
+                currentTile = nextTile;
+                nextTile = null;
+
+                // update the calling unit's "currentTile" parameter
+                if (gameObject.CompareTag("FireCrew"))
+                {
+                    gameObject.GetComponent<FireCrew>().currentTile = currentTile;
+                }
+                else if (gameObject.CompareTag("FireTruck"))
+                {
+                    gameObject.GetComponent<FireTruck>().currentTile = currentTile;
+                }
+
             }
             else
             {
-                // we are close enough to the next tile, so match position
-                gameObject.transform.position = nextTile.transform.position;
+                // keep moving to the next tile
+                Vector3 nextTilePosition = nextTile.transform.position;
+                float segmentLength = Vector3.Distance(currentTilePosition, nextTilePosition);
+                float totalSegmentTime = segmentLength / movementSpeed;
+                float timeOnSegment = Time.time - lastWaypointTime;
+                if (timeOnSegment < totalSegmentTime - 0.05)
+                {
+                    // we are far away from the next tile, so keep moving
+                    gameObject.transform.position = Vector2.Lerp(currentTilePosition, nextTilePosition, (timeOnSegment / totalSegmentTime));
+                }
+                else
+                {
+                    // we are close enough to the next tile, so match position
+                    gameObject.transform.position = nextTile.transform.position;
+
+                    // keep the calling unit's destination marker from moving
+                    if (gameObject.CompareTag("FireCrew"))
+                    {
+                        gameObject.GetComponent<FireCrew>().DestinationMarker.transform.position = destinationTile.transform.position;
+                    }
+                    else if (gameObject.CompareTag("FireTruck"))
+                    {
+                        gameObject.GetComponent<FireTruck>().DestinationMarker.transform.position = destinationTile.transform.position;
+                    }
+                }
+
             }
-
+            yield return null;
         }
-
-        yield return null;
     }
 }


### PR DESCRIPTION
MoveToDest's pathfinding algorithm is now prevented from backtracking, which ensures that the unit will not get stuck in a dilemma.
Further improvement is possible as the unit still does not always select the shortest route around obstacles.